### PR TITLE
fix: runtime env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # build environment
 FROM node:13.12.0-alpine as build
-ARG APIURL
-ARG APPNAME
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json ./
@@ -9,11 +7,12 @@ COPY package-lock.json ./
 RUN npm ci --silent
 RUN npm install react-scripts@3.4.1 -g --silent
 COPY . ./
-RUN export REACT_APP_APIURL=$APIURL REACT_APP_APPNAME=$APPNAME; npm run build 
+RUN npm run build 
 
 # production environment
 FROM nginx:stable-alpine
 COPY --from=build /app/build /usr/share/nginx/html
 COPY --from=build /app/nginx/nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Create the env-config.js file
+cat <<EOF > /usr/share/nginx/html/env-config.js
+window._env_ = {
+  APIURL: "$APIURL",
+  APPNAME: "$APPNAME",
+  // Add more environment variables here
+};
+EOF
+
+# Start Nginx
+nginx -g "daemon off;"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,8 +10,11 @@ server {
 
   error_page   500 502 503 504  /50x.html;
 
+  location /env-config.js {
+    alias /usr/share/nginx/html/env-config.js;
+  }
+  
   location = /50x.html {
     root   /usr/share/nginx/html;
   }
-
 }

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Flink Admin</title>
+    <script src="%PUBLIC_URL%/env-config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
+// @ts-ignore
+const _env_ = window._env_ || {};
+
 const config = {
-    "title" : process.env.REACT_APP_APPNAME || "Admin",
-    "api" : process.env.REACT_APP_APIURL || "http://localhost:3333/managementapi"
+  title: _env_.APPNAME || "Admin",
+  api: _env_.APIURL || "http://localhost:3333/managementapi",
 };
 export default config;


### PR DESCRIPTION
Exposes runtime env vars to make configuration simpler instead of relying on build time args.